### PR TITLE
Adds Validation Set to Preprocessing Pipeline

### DIFF
--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -116,11 +116,12 @@ def compute_standardization(
 def split_and_standardize(ds, climdata, var) -> dict:
     # Train test split
     logging.info("Splitting dataset...")
-    train_test = train_test_split(ds, climdata.select.time.test_years)
+    train_test = train_test_split(ds, climdata.select.time.test_years, climdata.select.time.validation_years)
 
     # Standardize the dataset.
     logging.info(f"Standardizing {var.name}...")
     train = compute_standardization(train_test["train"], var.name)
     test = compute_standardization(train_test["test"], var.name, train_test["train"])
+    validation = compute_standardization(train_test["validation"], var.name, train_test["train"])
 
-    return {"train": train, "test": test}
+    return {"train": train, "test": test, "validation": validation}

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -1,5 +1,6 @@
 import logging
 import xarray as xr
+import numpy as np  # noqa: F401
 from nc2pt.align import train_test_split
 from nc2pt.climatedata import ClimateVariable
 
@@ -116,12 +117,16 @@ def compute_standardization(
 def split_and_standardize(ds, climdata, var) -> dict:
     # Train test split
     logging.info("Splitting dataset...")
-    train_test = train_test_split(ds, climdata.select.time.test_years, climdata.select.time.validation_years)
+    train_test = train_test_split(
+        ds, climdata.select.time.test_years, climdata.select.time.validation_years
+    )
 
     # Standardize the dataset.
     logging.info(f"Standardizing {var.name}...")
     train = compute_standardization(train_test["train"], var.name)
     test = compute_standardization(train_test["test"], var.name, train_test["train"])
-    validation = compute_standardization(train_test["validation"], var.name, train_test["train"])
+    validation = compute_standardization(
+        train_test["validation"], var.name, train_test["train"]
+    )
 
     return {"train": train, "test": test, "validation": validation}

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -66,7 +66,7 @@ climate_models:
       _target_: nc2pt.climatedata.ClimateVariable
       name: "hr_ref"
       alternative_names: ["T2"]
-      path: nc2pt/nc2pt/data/hr_ref.nc
+      path: data/hr_ref.nc
       is_west_negative: true
 
     climate_variables:
@@ -86,7 +86,7 @@ climate_models:
         invariant: false
         transform:
           - "x * 3600"
-          - "np.log10(x + 1)"
+          # - "np.log10(x + 1)"
 
       - _target_: nc2pt.climatedata.ClimateVariable
         name: "Q2"
@@ -148,6 +148,7 @@ select:
       end: "20150928T12:00:00"
 
     # use this to select which years to reserve for testing
+    # and for validation
     # the remaining years in full will be used for training
     test_years: [2000, 2009, 2014]
     validation_years: [2015]

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -22,7 +22,7 @@ climate_models:
       - _target_: nc2pt.climatedata.ClimateVariable
         name: "pr"
         alternative_names: ["PREC"]
-        path: /home/nannau/USask-WRF-WCA/fire_vars/PREC/*.nc
+        path:  /home/nannau/USask-WRF-WCA/fire_vars/PREC/*.nc
         is_west_negative: true
         invariant: false
         transform: null
@@ -150,6 +150,7 @@ select:
     # use this to select which years to reserve for testing
     # the remaining years in full will be used for training
     test_years: [2000, 2009, 2014]
+    validation_years: [2015]
 
   # sets the scale factor and index slices of the rotated coordinates
   spatial:

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -85,12 +85,14 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         if climate_variable.invariant is False:
-            train_test_ds = split_and_standardize(ds, climdata, climate_variable)
-            for train_test in train_test_ds:
-                logging.info(f"Writing {train_test} output...")
+            train_test_validation_ds = split_and_standardize(
+                ds, climdata, climate_variable
+            )
+            for train_test_validation in train_test_validation_ds:
+                logging.info(f"Writing {train_test_validation} output...")
                 write_to_zarr(
-                    train_test_ds[train_test].chunk(chunk_dims),
-                    f"{climdata.output_path}/{climate_variable.name}_{train_test}_{model.name}",
+                    train_test_validation_ds[train_test_validation].chunk(chunk_dims),
+                    f"{climdata.output_path}/{climate_variable.name}_{train_test_validation}_{model.name}",
                 )
 
         else:

--- a/nc2pt/tests/test_align.py
+++ b/nc2pt/tests/test_align.py
@@ -147,12 +147,44 @@ def test_slice_time_count(ds, case: Dict[str, Any]):
 # Test train_test_split function
 train_test_split_cases = [
     # Happy path
-    {"id": "happy_path_normal_years", "years": [2000, 2001], "expected": 19_727},
+    {
+        "id": "happy_path_normal_years",
+        "test_years": [2000, 2001],
+        "validation_years": [2003],
+        "expected": None,
+    },
+    {
+        "id": "happy_path_normal_years",
+        "test_years": [2000],
+        "validation_years": [2001],
+        "expected": None,
+    },
     # edge case
-    {"id": "edge_case_single_year", "years": [2000], "expected": 2208},
+    {
+        "id": "edge_case_single_year",
+        "test_years": [2000],
+        "validation_years": [2000],
+        "expected": None,
+    },
     # error case
-    {"id": "error_case_empty_years", "years": [], "expected": ValueError},
-    {"id": "error_case_invalid_year", "years": 200, "expected": ValueError},
+    {
+        "id": "error_case_empty_years",
+        "test_years": [],
+        "validation_years": [],
+        "expected": ValueError,
+    },
+    {
+        "id": "error_case_invalid_year",
+        "test_years": 200,
+        "validation_years": [200],
+        "expected": ValueError,
+    },
+    {
+        "id": "error_case_invalid_year_validation",
+        "test_years": [200],
+        "validation_years": 200,
+        "expected": ValueError,
+    },
 ]
 
 
@@ -169,14 +201,15 @@ def test_train_test_split(case: Dict[str, Any]):
     if "error" in case["id"]:
         # Act & Assert
         with pytest.raises(case["expected"]):
-            train_test_split(ds, case["years"])
+            train_test_split(ds, case["test_years"], case["validation_years"])
     else:
         # Act
-        split_ds = train_test_split(ds, case["years"])
+        split_ds = train_test_split(ds, case["test_years"], case["validation_years"])
 
         # Assert
         assert "train" in split_ds
         assert "test" in split_ds
+        assert "validation" in split_ds
 
 
 x_large = np.ones((10, 100, 100))

--- a/nc2pt/tests/test_computations.py
+++ b/nc2pt/tests/test_computations.py
@@ -248,7 +248,9 @@ test_split_and_standardize_cases = [
     # Happy path
     {
         "id": "happy_path_normal_years",
-        "climatedata": OmegaConf.create({"select": {"time": {"test_years": [2000]}}}),
+        "climatedata": OmegaConf.create(
+            {"select": {"time": {"test_years": [2000], "validation_years": [2001]}}}
+        ),
         "var": OmegaConf.create({"name": "var"}),
     },
 ]
@@ -286,3 +288,10 @@ def test_split_and_standardize(case: Dict[str, Any]):
     assert np.isclose(
         result["test"]["var"].attrs["std"], result["train"]["var"].attrs["std"]
     ), "Std of train and test set are not equal."
+
+    assert np.isclose(
+        result["validation"]["var"].attrs["mean"], result["train"]["var"].attrs["mean"]
+    ), "Mean of train and validation set are not equal."
+    assert np.isclose(
+        result["validation"]["var"].attrs["std"], result["train"]["var"].attrs["std"]
+    ), "Std of train and validation set are not equal."

--- a/nc2pt/tests/test_config.yaml
+++ b/nc2pt/tests/test_config.yaml
@@ -108,6 +108,7 @@ select:
     # use this to select which years to reserve for testing
     # the remaining years in full will be used for training
     test_years: [2000, 2009, 2014]
+    validation_years: [2015]
 
   # sets the scale factor and index slices of the rotated coordinates
   spatial:

--- a/nc2pt/tests/test_config.yaml
+++ b/nc2pt/tests/test_config.yaml
@@ -106,6 +106,7 @@ select:
       end: "20250928T12:00:00"
 
     # use this to select which years to reserve for testing
+    # and for validation
     # the remaining years in full will be used for training
     test_years: [2000, 2009, 2014]
     validation_years: [2015]

--- a/nc2pt/tests/test_data/test1.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test1.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.853656"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.652362"
 }

--- a/nc2pt/tests/test_data/test1.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test1.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.789421"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.853656"
 }

--- a/nc2pt/tests/test_data/test1.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test1.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.921887"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.789421"
 }

--- a/nc2pt/tests/test_data/test1.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test1.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.789421"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.853656"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test1.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test1.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.853656"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.652362"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test1.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test1.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.921887"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.789421"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test2.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test2.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.874865"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.766783"
 }

--- a/nc2pt/tests/test_data/test2.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test2.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.953809"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.809813"
 }

--- a/nc2pt/tests/test_data/test2.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test2.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.809813"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.874865"
 }

--- a/nc2pt/tests/test_data/test2.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test2.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.809813"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.874865"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test2.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test2.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.953809"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.809813"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test2.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test2.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.874865"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.766783"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test_empty.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.956928"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.811594"
 }

--- a/nc2pt/tests/test_data/test_empty.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.876806"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.780377"
 }

--- a/nc2pt/tests/test_data/test_empty.zarr/.zattrs
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zattrs
@@ -1,3 +1,3 @@
 {
-    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.811594"
+    "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.876806"
 }

--- a/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.876806"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 14:32:08.780377"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-03 10:25:35.956928"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.811594"
         },
         ".zgroup": {
             "zarr_format": 2

--- a/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
+++ b/nc2pt/tests/test_data/test_empty.zarr/.zmetadata
@@ -1,7 +1,7 @@
 {
     "metadata": {
         ".zattrs": {
-            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 11:55:07.811594"
+            "history": "Created by /home/nannau/nc2pt/nc2pt/io.py on 2023-11-08 12:00:31.876806"
         },
         ".zgroup": {
             "zarr_format": 2


### PR DESCRIPTION
The following PR:
* Adds validation years instead of just having test years
* These validation years are processed identically to test years but are meant for monitoring during training
* This forces no contamination between train and test years. 

Should resolve #7 