### PR TITLE
Requirements typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ hydra-core==1.3.2
 h5netcdf
 torch
 distributed
+parallelbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ netCDF4
 hydra-core==1.3.2
 h5netcdf
 torch
-distriubted
+distributed


### PR DESCRIPTION
Issue #27 

A couple updates to `requirements.txt`

- fixed typo in 'distributed'
- added `parallelbar` dependency which is needed for `zarr_to_torch.py`