### PR TITLE
add a filter to ensure chunk dimensions match ds dimensions

### DIFF
--- a/nc2pt/tools/zarr_to_torch.py
+++ b/nc2pt/tools/zarr_to_torch.py
@@ -38,6 +38,7 @@ def loop_over_variables(climate_data, model, var, s):
         f"{output_path}/{var.name}_{s}_{model.name}.zarr/", chunks=chunks
     ) as ds:
         ds = ds.sortby("time")
+        chunks = {dim: size for dim, size in chunks.items() if dim in ds.dims}
         # Create parent dir if it doesn't exist for each variable
         make_dirs(output_path, s, var.name, model.name)
         indices = ds.time.dt.strftime("%Y-%m-%d-%H").values

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ hydra-core==1.3.2
 h5netcdf
 torch
 distributed
+parallelbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ netCDF4
 hydra-core==1.3.2
 h5netcdf
 torch
-distriubted
+distributed


### PR DESCRIPTION
### 🛠️ Fix: Dimension mismatch in `zarr_to_torch.py` during transpose

**What this PR does:**
Fixes a `ValueError` when calling `.transpose()` on variables that don't share dimensions with the `chunks` dictionary (e.g., `'lat'`/`'lon'` in LR datasets vs `'rlat'`/`'rlon'` in WRF).

**Fix implemented:**
Filtered `chunks` in-place to keep only dimensions present in the target `xarray.Dataset`:
```python
chunks = {dim: size for dim, size in chunks.items() if dim in ds.dims}
```
**Why this is needed**: Prevents failure when processing HR datasets that use different dimension names, allowing mixed LR/HR workflows to proceed without error.

Closes #29 