### PR TITLE
Add customizable alignment pipeline per model via alignment_pipeline config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,37 @@ High-level workflow
 2. slices data to a pre-determined range of dates
 3. aligns the grids via interpolation, crops them to be the same size, and coarsens the low-resolution fields by the configured scale factor
 4. applies user defined transforms like unit conversions or log transformations
-5. splits into a train and test dataset and standardizes both datasets based on the mean and standard deviation of all grids from the training data only (also writes this information into the zarr metadata for inference)
-6. writes to `.zarr`
-7. `nc2pt/tools/zarr_to_torch.py` - writes to PyTorch files
-8. `nc2pt/tools/single_file_to_batches.py` - batches the single PyTorch files
+5. optionally splits into train/test/validation based on years defined in the config
+6. standardizes/normalizes the datasets based on statistics computed from the training data (or full data, if no split). These statistics are stored in the metadata.
+7. writes to `.zarr`
+8. `nc2pt/tools/zarr_to_torch.py` - writes to PyTorch files
+9. `nc2pt/tools/single_file_to_batches.py` - batches the single PyTorch files
+
+## Customizable Pipelines 🚦
+
+Each model can define its own custom preprocessing steps by listing them in order via the `alignment_pipeline` field of the model YAML. Steps include:
+
+-   `temporal_crop`
+    
+-   `regrid`
+    
+-   `spatial_crop`
+    
+-   `coarsen`
+
+-   `user_defined_transforms`
+    
+-   `data_split`
+    
+
+By default, all 6 are applied. You can exclude or reorder them by editing the YAML, e.g.:
+
+```
+alignment_pipeline:
+  - temporal_crop
+  - regrid
+  - spatial_crop
+```
 
 ## What are the downsides of using PyTorch files for climate data?
 The most obvious downside is that you lose the metadata associated with a netCDF dataset. The intermediate Zarr format produced by nc2pt allows for parallelized io and perserves the metadata. This is useful for inference. 
@@ -107,6 +134,13 @@ To add a new model:
     _target_:  nc2pt.climatedata.ClimateModel
     name:  my_model
     info:  "My custom climate model"
+	alignment_pipeline:
+      - temporal_crop
+      - regrid
+      - spatial_crop
+      - coarsen
+	  - user_defined_transforms
+      - data_split
     climate_variables:
 	    -  ${internal.my_model_pr}
 	    -  ${internal.my_model_tas}
@@ -154,6 +188,7 @@ To add a new variable to an existing model (e.g., `hr`):
 	    apply_standardize:  true
 	    apply_normalize:  true
 	    invariant:  false
+		transform: ["x * 69 + 420"]
 	 ```
     
 2.  **Register and alias it in `injections.yaml`**

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -5,7 +5,7 @@ import pandas as pd
 import xarray as xr
 
 from nc2pt.climatedata import ClimateData, ClimateModel, ClimateVariable
-from nc2pt.computations import compute_normalization, compute_standardization
+from nc2pt.computations import compute_normalization, compute_standardization, user_defined_transform
 import omegaconf
 
 
@@ -261,6 +261,7 @@ def coarsen_lr(ds: xr.DataArray, scale_factor: int) -> xr.DataArray:
 
 def apply_temporal_crop(ds: xr.DataArray,
                         model: ClimateModel,
+                        var: ClimateVariable,
                         climdata: ClimateData,
                         hr_ref: xr.DataArray) -> xr.DataArray:
     """
@@ -270,8 +271,10 @@ def apply_temporal_crop(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         The input dataset.
+    var : ClimateVariable
+        Unused in this function; included for interface compatibility.
     model : ClimateModel
-        The climate model configuration.
+        Unused in this function; included for interface compatibility.
     climdata : ClimateData
         Global configuration object with time selection settings.
     hr_ref : xr.DataArray
@@ -289,6 +292,7 @@ def apply_temporal_crop(ds: xr.DataArray,
 
 
 def apply_regrid(ds: xr.DataArray,
+                 var: ClimateVariable,
                  model: ClimateModel,
                  climdata: ClimateData,
                  hr_ref: xr.DataArray) -> xr.DataArray:
@@ -299,10 +303,12 @@ def apply_regrid(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         The input dataset to regrid.
+    var : ClimateVariable
+        Unused in this function; included for interface compatibility.
     model : ClimateModel
         The climate model configuration.
     climdata : ClimateData
-        Global configuration object.
+        Unused in this function; included for interface compatibility.
     hr_ref : xr.DataArray
         High-resolution reference dataset.
 
@@ -329,6 +335,7 @@ def apply_regrid(ds: xr.DataArray,
 
 
 def apply_spatial_crop(ds: xr.DataArray,
+                       var: ClimateVariable,
                        model: ClimateModel,
                        climdata: ClimateData,
                        hr_ref: xr.DataArray) -> xr.DataArray:
@@ -339,8 +346,10 @@ def apply_spatial_crop(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         The input dataset to crop.
+    var : ClimateVariable
+        Unused in this function; included for interface compatibility.
     model : ClimateModel
-        The climate model configuration.
+        Unused in this function; included for interface compatibility.
     climdata : ClimateData
         Global configuration containing crop index bounds.
     hr_ref : xr.DataArray
@@ -360,6 +369,7 @@ def apply_spatial_crop(ds: xr.DataArray,
 
 
 def apply_coarsen(ds: xr.DataArray,
+                  var: ClimateVariable,
                   model: ClimateModel,
                   climdata: ClimateData,
                   hr_ref: xr.DataArray) -> xr.DataArray:
@@ -370,8 +380,10 @@ def apply_coarsen(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         The input dataset to coarsen.
+    var : ClimateVariable
+        Unused in this function; included for interface compatibility.
     model : ClimateModel
-        The climate model configuration.
+        Unused in this function; included for interface compatibility.
     climdata : ClimateData
         Global configuration containing coarsening parameters.
     hr_ref : xr.DataArray
@@ -388,7 +400,17 @@ def apply_coarsen(ds: xr.DataArray,
     return ds
 
 
+def apply_user_defined_transforms(ds: xr.DataArray,
+                                  var: ClimateVariable,
+                                  model: ClimateModel,
+                                  climdata: ClimateData,
+                                  hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+
+    return user_defined_transform(ds, var)
+
+
 def apply_data_split(ds: xr.DataArray,
+                     var: ClimateVariable,
                      model: ClimateModel,
                      climdata: ClimateData,
                      hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
@@ -399,8 +421,10 @@ def apply_data_split(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         The input dataset to split.
+    var : ClimateVariable
+        Unused in this function; included for interface compatibility.
     model : ClimateModel
-        The climate model configuration.
+        Unused in this function; included for interface compatibility.
     climdata : ClimateData
         Global configuration containing year splits.
     hr_ref : xr.DataArray
@@ -419,6 +443,7 @@ def apply_data_split(ds: xr.DataArray,
 
 
 def run_alignment_pipeline(ds: xr.DataArray,
+                           var: ClimateVariable,
                            model: ClimateModel,
                            climdata: ClimateData,
                            hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
@@ -429,6 +454,8 @@ def run_alignment_pipeline(ds: xr.DataArray,
     ----------
     ds : xr.DataArray
         Input dataset to process.
+    var : ClimateVariable
+        Climate variable containing custom transformation proceedures.
     model : ClimateModel
         Climate model containing the alignment pipeline steps.
     climdata : ClimateData
@@ -450,7 +477,7 @@ def run_alignment_pipeline(ds: xr.DataArray,
     for step in model.alignment_pipeline:
         if step not in alignment_steps:
             raise ValueError(f"Unknown alignment step '{step}' in model '{model.name}'")
-        ds = alignment_steps[step](ds, model, climdata, hr_ref)
+        ds = alignment_steps[step](ds, var, model, climdata, hr_ref)
 
     if not isinstance(ds, dict):
         ds = {"full": ds}
@@ -462,6 +489,7 @@ alignment_steps: dict[str, Callable] = {
     "regrid": apply_regrid,
     "spatial_crop": apply_spatial_crop,
     "coarsen": apply_coarsen,
+    "user_defined_transforms": apply_user_defined_transforms,
     "split_data": apply_data_split,
 }
 

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -129,11 +129,6 @@ def crop_field(ds: xr.DataArray, scale_factor: int, x: dict, y: dict, downsample
         ds.rlon.size == ds.rlat.size
     ), "rlon and rlat not the same size, check dataset"
 
-    # if downsample:
-    #     # Optional coarsen for low resolution invariant fields.
-    #     logging.info("🌎 Coarsening HR invariant to become LR invariant...")
-    #     ds = coarsen_lr(ds, scale_factor)
-
     return ds
 
 
@@ -182,59 +177,6 @@ def interpolate(ds: xr.Dataset, grid: xr.Dataset) -> xr.Dataset:
         lon=interp_points["lon"],
         method="linear"
     )
-    return ds
-
-
-def align_grid(
-    ds: xr.DataArray, hr_ref: xr.DataArray, climdata: ClimateData
-) -> xr.DataArray:
-    """Processes low resolution dataset for machine learning.
-
-    Regrids, aligns, crops, and coarsens the low resolution dataset for use in machine learning.
-
-    Args:
-    ds: Low resolution xarray dataset.
-    climdata: Climate data configuration object.
-
-    Returns:
-    Processed low resolution xarray dataset.
-    """
-    # Regrid and align the dataset.
-    logging.info("🚀 Regridding and interpolating...")
-    ds = interpolate(ds, hr_ref)
-
-    # Crop the field to the given size.
-    logging.info("🌎 Cropping field...")
-    ds = crop_field(
-        ds,
-        climdata.select.spatial.scale_factor,
-        climdata.select.spatial.x,
-        climdata.select.spatial.y,
-    )
-    ds = ds.drop_vars(["lat", "lon"])
-
-    return ds
-
-
-def align_with_lr(ds, hr_ref, climdata) -> xr.Dataset:
-    """Processes low resolution dataset for machine learning.
-
-    Regrids, aligns, crops, and coarsens the low resolution dataset for use in machine learning.
-
-    Args:
-    ds: Low resolution xarray dataset.
-    climdata: Climate data configuration object.
-
-    Returns:
-    Processed low resolution xarray dataset.
-    """
-    # Regrid and align the dataset.
-    ds = align_grid(ds, hr_ref, climdata)
-
-    # Coarsen the low resolution dataset.
-    logging.info("🌎 Coarsening low resolution dataset...")
-    ds = coarsen_lr(ds, climdata.select.spatial.scale_factor)
-
     return ds
 
 
@@ -404,8 +346,28 @@ def apply_user_defined_transforms(ds: xr.DataArray,
                                   var: ClimateVariable,
                                   model: ClimateModel,
                                   climdata: ClimateData,
-                                  hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+                                  hr_ref: xr.DataArray) -> xr.DataArray:
+    """
+    Apply user-defined transformations to the input dataset.
 
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset to transform.
+    var : ClimateVariable
+        Contains transformation instructions (e.g., unit conversions or log-scaling).
+    model : ClimateModel
+        Unused in this function; included for interface compatibility.
+    climdata : ClimateData
+        Unused in this function; included for interface compatibility.
+    hr_ref : xr.DataArray
+        Unused in this function; included for interface compatibility.
+
+    Returns
+    -------
+    xr.DataArray
+        Transformed dataset.
+    """
     return user_defined_transform(ds, var)
 
 

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -262,6 +262,25 @@ def apply_temporal_crop(ds: xr.DataArray,
                         model: ClimateModel,
                         climdata: ClimateData,
                         hr_ref: xr.DataArray) -> xr.DataArray:
+    """
+    Crop the dataset to the configured start and end times.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset.
+    model : ClimateModel
+        The climate model configuration.
+    climdata : ClimateData
+        Global configuration object with time selection settings.
+    hr_ref : xr.DataArray
+        Unused in this function; included for interface compatibility.
+
+    Returns
+    -------
+    xr.DataArray
+        Time-cropped dataset.
+    """
     start = climdata.select.time.range.start
     end = climdata.select.time.range.end
     ds = slice_time(ds, start, end)
@@ -272,14 +291,38 @@ def apply_regrid(ds: xr.DataArray,
                  model: ClimateModel,
                  climdata: ClimateData,
                  hr_ref: xr.DataArray) -> xr.DataArray:
+    """
+    Regrid the dataset to match a high-resolution reference field.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset to regrid.
+    model : ClimateModel
+        The climate model configuration.
+    climdata : ClimateData
+        Global configuration object.
+    hr_ref : xr.DataArray
+        High-resolution reference dataset.
+
+    Returns
+    -------
+    xr.DataArray
+        Regridded dataset.
+
+    Raises
+    ------
+    ValueError
+        If no hr_ref is provided in the model configuration.
+    """
     logging.info("🚀 Regridding and interpolating...")
 
     if hr_ref is None:
         raise ValueError(
-                f"Cannot perform 'regrid' step for model '{model.name}': "
-                f"'hr_ref' (the high-resolution reference field) is not defined.\n"
-                f"To enable regridding, add an 'hr_ref' field to the model YAML."
-                )
+            f"Cannot perform 'regrid' step for model '{model.name}': "
+            f"'hr_ref' (the high-resolution reference field) is not defined.\n"
+            f"To enable regridding, add an 'hr_ref' field to the model YAML."
+        )
     ds = interpolate(ds, hr_ref)
     return ds
 
@@ -288,6 +331,25 @@ def apply_spatial_crop(ds: xr.DataArray,
                        model: ClimateModel,
                        climdata: ClimateData,
                        hr_ref: xr.DataArray) -> xr.DataArray:
+    """
+    Crop the dataset spatially to configured x/y index bounds.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset to crop.
+    model : ClimateModel
+        The climate model configuration.
+    climdata : ClimateData
+        Global configuration containing crop index bounds.
+    hr_ref : xr.DataArray
+        Unused in this function; included for interface compatibility.
+
+    Returns
+    -------
+    xr.DataArray
+        Cropped dataset.
+    """
     scale_factor = climdata.select.spatial.scale_factor
     x_range = climdata.select.spatial.x
     y_range = climdata.select.spatial.y
@@ -300,6 +362,25 @@ def apply_coarsen(ds: xr.DataArray,
                   model: ClimateModel,
                   climdata: ClimateData,
                   hr_ref: xr.DataArray) -> xr.DataArray:
+    """
+    Coarsen the dataset spatially by a configured scale factor.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset to coarsen.
+    model : ClimateModel
+        The climate model configuration.
+    climdata : ClimateData
+        Global configuration containing coarsening parameters.
+    hr_ref : xr.DataArray
+        Unused in this function; included for interface compatibility.
+
+    Returns
+    -------
+    xr.DataArray
+        Coarsened dataset.
+    """
     scale_factor = climdata.select.spatial.scale_factor
     coarsen_lr(ds, scale_factor)
     logging.info(f"🪛  Coarsened field by a factor of {scale_factor}")
@@ -309,12 +390,30 @@ def apply_coarsen(ds: xr.DataArray,
 def apply_data_split(ds: xr.DataArray,
                      model: ClimateModel,
                      climdata: ClimateData,
-                     hr_ref: xr.DataArray) -> xr.DataArray:
+                     hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+    """
+    Split the dataset into training, validation, and test sets based on years.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        The input dataset to split.
+    model : ClimateModel
+        The climate model configuration.
+    climdata : ClimateData
+        Global configuration containing year splits.
+    hr_ref : xr.DataArray
+        Unused in this function; included for interface compatibility.
+
+    Returns
+    -------
+    dict[str, xr.DataArray]
+        Dictionary containing split datasets keyed by "train", "test", and "validation".
+    """
     test_years = climdata.select.time.test_years
     validation_years = climdata.select.time.validation_years
     full_ds = train_test_split(ds, test_years, validation_years)
     logging.info(f"🪓  Split dataset into test years: {test_years}, validation years: {validation_years}, and training years (remainder)")
-
     return full_ds
 
 
@@ -322,19 +421,38 @@ def run_alignment_pipeline(ds: xr.DataArray,
                            model: ClimateModel,
                            climdata: ClimateData,
                            hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+    """
+    Execute the alignment pipeline for a given climate model.
+
+    Parameters
+    ----------
+    ds : xr.DataArray
+        Input dataset to process.
+    model : ClimateModel
+        Climate model containing the alignment pipeline steps.
+    climdata : ClimateData
+        Global configuration for the preprocessing run.
+    hr_ref : xr.DataArray
+        Optional high-resolution reference field for regridding.
+
+    Returns
+    -------
+    dict[str, xr.DataArray]
+        Processed dataset(s), returned as a dictionary.
+        If no split is performed, a single entry with key "full" is returned.
+
+    Raises
+    ------
+    ValueError
+        If an unknown step is found in the model's pipeline.
+    """
     for step in model.alignment_pipeline:
         if step not in alignment_steps:
             raise ValueError(f"Unknown alignment step '{step}' in model '{model.name}'")
         ds = alignment_steps[step](ds, model, climdata, hr_ref)
-    
-    # ensure that the output of this function is a dict, even if the dataset
-    # has not been split
+
     if not isinstance(ds, dict):
-        ds = {
-            "full": ds
-        }
-
-
+        ds = {"full": ds}
     return ds
 
 

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Dict
+from typing import Dict, Callable
 
 import pandas as pd
 import xarray as xr
 
-from nc2pt.climatedata import ClimateData
+from nc2pt.climatedata import ClimateData, ClimateModel
 import omegaconf
 
 
@@ -41,6 +41,7 @@ def slice_time(ds: xr.Dataset, start: str, end: str) -> xr.Dataset:
         raise ValueError("End date is after the dataset ends.")
 
     ds = ds.sel(time=slice(start, end), drop=True)
+    logging.info(f"🕜 Cropped dataset temporally from {start} to {end}")
 
     return ds
 
@@ -88,7 +89,7 @@ def train_test_split(
     return {"train": train, "test": test, "validation": validation}
 
 
-def crop_field(ds, scale_factor, x, y, downsample=False):
+def crop_field(ds: xr.DataArray, scale_factor: int, x: dict, y: dict, downsample=False) -> xr.DataArray:
     """Crop the field to the given size.
 
     Parameters
@@ -127,10 +128,10 @@ def crop_field(ds, scale_factor, x, y, downsample=False):
         ds.rlon.size == ds.rlat.size
     ), "rlon and rlat not the same size, check dataset"
 
-    if downsample:
-        # Optional coarsen for low resolution invariant fields.
-        logging.info("🌎 Coarsening HR invariant to become LR invariant...")
-        ds = coarsen_lr(ds, scale_factor)
+    # if downsample:
+    #     # Optional coarsen for low resolution invariant fields.
+    #     logging.info("🌎 Coarsening HR invariant to become LR invariant...")
+    #     ds = coarsen_lr(ds, scale_factor)
 
     return ds
 
@@ -236,7 +237,7 @@ def align_with_lr(ds, hr_ref, climdata) -> xr.Dataset:
     return ds
 
 
-def coarsen_lr(ds, scale_factor):
+def coarsen_lr(ds: xr.DataArray, scale_factor: int) -> xr.DataArray:
     """Coarsen the low resolution dataset.
 
     Parameters
@@ -255,3 +256,92 @@ def coarsen_lr(ds, scale_factor):
     ds = ds.coarsen(rlon=scale_factor, rlat=scale_factor).mean()
 
     return ds
+
+
+def apply_temporal_crop(ds: xr.DataArray,
+                        model: ClimateModel,
+                        climdata: ClimateData,
+                        hr_ref: xr.DataArray) -> xr.DataArray:
+    start = climdata.select.time.range.start
+    end = climdata.select.time.range.end
+    ds = slice_time(ds, start, end)
+    return ds
+
+
+def apply_regrid(ds: xr.DataArray,
+                 model: ClimateModel,
+                 climdata: ClimateData,
+                 hr_ref: xr.DataArray) -> xr.DataArray:
+    logging.info("🚀 Regridding and interpolating...")
+
+    if hr_ref is None:
+        raise ValueError(
+                f"Cannot perform 'regrid' step for model '{model.name}': "
+                f"'hr_ref' (the high-resolution reference field) is not defined.\n"
+                f"To enable regridding, add an 'hr_ref' field to the model YAML."
+                )
+    ds = interpolate(ds, hr_ref)
+    return ds
+
+
+def apply_spatial_crop(ds: xr.DataArray,
+                       model: ClimateModel,
+                       climdata: ClimateData,
+                       hr_ref: xr.DataArray) -> xr.DataArray:
+    scale_factor = climdata.select.spatial.scale_factor
+    x_range = climdata.select.spatial.x
+    y_range = climdata.select.spatial.y
+    ds = crop_field(ds, scale_factor, x_range, y_range)
+    logging.info(f"🌎 Cropped field to x:[{x_range.first_index},{x_range.last_index}] and y:[{y_range.first_index}, {y_range.last_index}]")
+    return ds
+
+
+def apply_coarsen(ds: xr.DataArray,
+                  model: ClimateModel,
+                  climdata: ClimateData,
+                  hr_ref: xr.DataArray) -> xr.DataArray:
+    scale_factor = climdata.select.spatial.scale_factor
+    coarsen_lr(ds, scale_factor)
+    logging.info(f"🪛  Coarsened field by a factor of {scale_factor}")
+    return ds
+
+
+def apply_data_split(ds: xr.DataArray,
+                     model: ClimateModel,
+                     climdata: ClimateData,
+                     hr_ref: xr.DataArray) -> xr.DataArray:
+    test_years = climdata.select.time.test_years
+    validation_years = climdata.select.time.validation_years
+    full_ds = train_test_split(ds, test_years, validation_years)
+    logging.info(f"🪓  Split dataset into test years: {test_years}, validation years: {validation_years}, and training years (remainder)")
+
+    return full_ds
+
+
+def run_alignment_pipeline(ds: xr.DataArray,
+                           model: ClimateModel,
+                           climdata: ClimateData,
+                           hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+    for step in model.alignment_pipeline:
+        if step not in alignment_steps:
+            raise ValueError(f"Unknown alignment step '{step}' in model '{model.name}'")
+        ds = alignment_steps[step](ds, model, climdata, hr_ref)
+    
+    # ensure that the output of this function is a dict, even if the dataset
+    # has not been split
+    if not isinstance(ds, dict):
+        ds = {
+            "full": ds
+        }
+
+
+    return ds
+
+
+alignment_steps: dict[str, Callable] = {
+    "temporal_crop": apply_temporal_crop,
+    "regrid": apply_regrid,
+    "spatial_crop": apply_spatial_crop,
+    "coarsen": apply_coarsen,
+    "split_data": apply_data_split,
+}

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -4,7 +4,8 @@ from typing import Dict, Callable
 import pandas as pd
 import xarray as xr
 
-from nc2pt.climatedata import ClimateData, ClimateModel
+from nc2pt.climatedata import ClimateData, ClimateModel, ClimateVariable
+from nc2pt.computations import compute_normalization, compute_standardization
 import omegaconf
 
 
@@ -463,3 +464,54 @@ alignment_steps: dict[str, Callable] = {
     "coarsen": apply_coarsen,
     "split_data": apply_data_split,
 }
+
+
+def apply_feature_scaling(
+    ds_dict: dict[str, xr.Dataset],
+    var: ClimateVariable
+) -> dict[str, xr.Dataset]:
+    """
+    Applies standardization or normalization to datasets in a dictionary.
+    If train/test/validation keys are provided, uses training statistics
+    for all splits. If only 'full' is present, scales in-place.
+
+    Parameters
+    ----------
+    ds_dict : dict[str, xr.Dataset]
+        Dictionary containing datasets to be scaled. Must contain either:
+        - 'train', 'test', 'validation', or
+        - 'full'
+    var : ClimateVariable
+        Variable config containing scaling flags and variable name.
+
+    Returns
+    -------
+    dict[str, xr.Dataset]
+        Same keys as input, with values scaled according to the config.
+    """
+    varname = var.name
+
+    if var.apply_standardize:
+        logging.info(f"📏 Standardizing {varname}...")
+        if "train" in ds_dict:
+            train = compute_standardization(ds_dict["train"], varname)
+            test = compute_standardization(ds_dict["test"], varname, ds_dict["train"])
+            val = compute_standardization(ds_dict["validation"], varname, ds_dict["train"])
+            return {"train": train, "test": test, "validation": val}
+        elif "full" in ds_dict:
+            full = compute_standardization(ds_dict["full"], varname)
+            return {"full": full}
+
+    if var.apply_normalize:
+        logging.info(f"📐 Normalizing {varname}...")
+        if "train" in ds_dict:
+            train = compute_normalization(ds_dict["train"], varname)
+            test = compute_normalization(ds_dict["test"], varname, ds_dict["train"])
+            val = compute_normalization(ds_dict["validation"], varname, ds_dict["train"])
+            return {"train": train, "test": test, "validation": val}
+        elif "full" in ds_dict:
+            full = compute_normalization(ds_dict["full"], varname)
+            return {"full": full}
+
+    logging.info(f"🚫 Skipping standardization and normalization for {varname}")
+    return ds_dict

--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -35,6 +35,9 @@ class ClimateModel:
     hr_ref: Optional[ClimateVariable] = None
     engine: Optional[str] = None  # Optional engine override for this model
     downsample: Optional[bool] = False  # Optional downsampling for invariant fields
+    alignment_pipeline: List[str] = field(default_factory=lambda: [
+        "temporal_crop", "regrid", "spatial_crop", "coarsen", "split_data"
+    ])
 
 
 @dataclass

--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -36,7 +36,7 @@ class ClimateModel:
     engine: Optional[str] = None  # Optional engine override for this model
     downsample: Optional[bool] = False  # Optional downsampling for invariant fields
     alignment_pipeline: List[str] = field(default_factory=lambda: [
-        "temporal_crop", "regrid", "spatial_crop", "coarsen", "split_data"
+        "temporal_crop", "regrid", "spatial_crop", "coarsen", "user_defined_transforms", "split_data"
     ])
 
 

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -1,7 +1,6 @@
 import logging
 import xarray as xr
-import numpy as np  # noqa: F401
-#from nc2pt.align import train_test_split
+import numpy as np  # noqa: F401s
 from nc2pt.climatedata import ClimateVariable
 
 
@@ -45,6 +44,7 @@ def user_defined_transform(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
 
 
 def compute_normalization(ds, varname, precomputed=None):
+    logging.info(f"Normalizing {varname}...")
     if precomputed is None:
         logging.info("Computing min and max...")
         logging.info("Calculation min...")
@@ -121,6 +121,7 @@ def compute_standardization(
     ds : xarray.Dataset
         Dataset with standardized statistics.
     """
+    logging.info(f"Standardizing {varname}...")
     logging.info("Computing mean and standard deviation...")
     if precomputed is None:
         logging.info("Calculation mean...")
@@ -148,84 +149,5 @@ def compute_standardization(
 
     ds[varname].attrs["mean"] = float(mean)
     ds[varname].attrs["std"] = float(std)
-
-    return ds
-
-
-# def split_and_standardize(ds, climdata, var) -> dict:
-#     # Train test split
-#     logging.info("Splitting dataset...")
-
-#     ds = user_defined_transform(ds, var)
-
-#     train_test = train_test_split(
-#         ds, climdata.select.time.test_years, climdata.select.time.validation_years
-#     )
-
-#     # Standardize the dataset.
-#     if var.apply_standardize:
-#         logging.info(f"Standardizing {var.name}...")
-#         train = compute_standardization(train_test["train"], var.name)
-#         test = compute_standardization(
-#             train_test["test"], var.name, train_test["train"]
-#         )
-#         validation = compute_standardization(
-#             train_test["validation"], var.name, train_test["train"]
-#         )
-
-#     if var.apply_normalize:
-#         logging.info(f"Normalizing {var.name}...")
-#         train = compute_normalization(train_test["train"], var.name)
-#         test = compute_normalization(train_test["test"], var.name, train_test["train"])
-#         validation = compute_normalization(
-#             train_test["validation"], var.name, train_test["train"]
-#         )
-
-#     if var.apply_normalize is False and var.apply_standardize is False:
-#         logging.info("Skipping standardization and normalization...")
-#         return {
-#             "train": train_test["train"],
-#             "test": train_test["test"],
-#             "validation": train_test["validation"],
-#         }
-
-#     return {"train": train, "test": test, "validation": validation}
-
-
-def standardize_or_normalize(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
-    """
-    Apply user-defined transformation, standardization, and normalization
-    to a dataset for a given ClimateVariable.
-
-    Parameters
-    ----------
-    ds : xr.Dataset
-        The input dataset containing the variable to transform.
-    var : ClimateVariable
-        The ClimateVariable object containing transformation and scaling flags.
-
-    Returns
-    -------
-    xr.Dataset
-        The dataset with the variable transformed, standardized, and/or normalized.
-
-    Notes
-    -----
-    - Applies a user-defined transformation first (if any).
-    - Standardization and normalization are applied in sequence.
-    - If neither is requested, logs that the step was skipped.
-    """
-    ds = user_defined_transform(ds, var)
-
-    if var.apply_standardize:
-        logging.info(f"Standardizing {var.name}...")
-        ds = compute_standardization(ds, var.name)
-
-    elif var.apply_normalize:
-        logging.info(f"Normalizing {var.name}...")
-        ds = compute_normalization(ds, var.name)
-
-    else:
-        logging.info(f"Skipping standardization and normalization for {var.name}.")
 
     return ds

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -1,7 +1,7 @@
 import logging
 import xarray as xr
 import numpy as np  # noqa: F401
-from nc2pt.align import train_test_split
+#from nc2pt.align import train_test_split
 from nc2pt.climatedata import ClimateVariable
 
 
@@ -152,44 +152,44 @@ def compute_standardization(
     return ds
 
 
-def split_and_standardize(ds, climdata, var) -> dict:
-    # Train test split
-    logging.info("Splitting dataset...")
+# def split_and_standardize(ds, climdata, var) -> dict:
+#     # Train test split
+#     logging.info("Splitting dataset...")
 
-    ds = user_defined_transform(ds, var)
+#     ds = user_defined_transform(ds, var)
 
-    train_test = train_test_split(
-        ds, climdata.select.time.test_years, climdata.select.time.validation_years
-    )
+#     train_test = train_test_split(
+#         ds, climdata.select.time.test_years, climdata.select.time.validation_years
+#     )
 
-    # Standardize the dataset.
-    if var.apply_standardize:
-        logging.info(f"Standardizing {var.name}...")
-        train = compute_standardization(train_test["train"], var.name)
-        test = compute_standardization(
-            train_test["test"], var.name, train_test["train"]
-        )
-        validation = compute_standardization(
-            train_test["validation"], var.name, train_test["train"]
-        )
+#     # Standardize the dataset.
+#     if var.apply_standardize:
+#         logging.info(f"Standardizing {var.name}...")
+#         train = compute_standardization(train_test["train"], var.name)
+#         test = compute_standardization(
+#             train_test["test"], var.name, train_test["train"]
+#         )
+#         validation = compute_standardization(
+#             train_test["validation"], var.name, train_test["train"]
+#         )
 
-    if var.apply_normalize:
-        logging.info(f"Normalizing {var.name}...")
-        train = compute_normalization(train_test["train"], var.name)
-        test = compute_normalization(train_test["test"], var.name, train_test["train"])
-        validation = compute_normalization(
-            train_test["validation"], var.name, train_test["train"]
-        )
+#     if var.apply_normalize:
+#         logging.info(f"Normalizing {var.name}...")
+#         train = compute_normalization(train_test["train"], var.name)
+#         test = compute_normalization(train_test["test"], var.name, train_test["train"])
+#         validation = compute_normalization(
+#             train_test["validation"], var.name, train_test["train"]
+#         )
 
-    if var.apply_normalize is False and var.apply_standardize is False:
-        logging.info("Skipping standardization and normalization...")
-        return {
-            "train": train_test["train"],
-            "test": train_test["test"],
-            "validation": train_test["validation"],
-        }
+#     if var.apply_normalize is False and var.apply_standardize is False:
+#         logging.info("Skipping standardization and normalization...")
+#         return {
+#             "train": train_test["train"],
+#             "test": train_test["test"],
+#             "validation": train_test["validation"],
+#         }
 
-    return {"train": train, "test": test, "validation": validation}
+#     return {"train": train, "test": test, "validation": validation}
 
 
 def standardize_or_normalize(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -38,7 +38,7 @@ def user_defined_transform(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
         def func(x):
             return eval(transform)
 
-        logging.info(f"Applying transform {transform} to {var.name}...")
+        logging.info(f"🧮 Applying transform {transform} to {var.name}...")
         ds[var.name] = xr.apply_ufunc(func, ds[var.name], dask="parallelized")
 
     return ds

--- a/nc2pt/conf/climate_models/lr.yaml
+++ b/nc2pt/conf/climate_models/lr.yaml
@@ -6,7 +6,7 @@
 _target_: nc2pt.climatedata.ClimateModel
 name: lr
 info: "Low resolution ERA5, Western Canada"
-alignment_pipeline: ["temporal_crop", "regrid", "spatial_crop", "coarsen", "split_data"]
+alignment_pipeline: ["temporal_crop", "regrid", "spatial_crop", "coarsen", "user_defined_transforms", "split_data"]
 
 # Used to interpolate LR data to HR grid. This is typically a high-res field like T2.
 hr_ref:

--- a/nc2pt/conf/climate_models/lr.yaml
+++ b/nc2pt/conf/climate_models/lr.yaml
@@ -6,6 +6,7 @@
 _target_: nc2pt.climatedata.ClimateModel
 name: lr
 info: "Low resolution ERA5, Western Canada"
+alignment_pipeline: ["temporal_crop", "regrid", "spatial_crop", "coarsen", "split_data"]
 
 # Used to interpolate LR data to HR grid. This is typically a high-res field like T2.
 hr_ref:

--- a/nc2pt/conf/climate_models/lr_invariant.yaml
+++ b/nc2pt/conf/climate_models/lr_invariant.yaml
@@ -7,6 +7,7 @@ name: lr_invariant
 info: "HR static invariant fields for WRF domain to be downsampled to LR"
 engine: netcdf4
 downsample: true
+alignment_pipeline: ['spatial_crop', 'coarsen']
 
 climate_variables:
   - ${internal.hr_invariant_topo}

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -25,3 +25,4 @@ climate_models:
   - ${internal.lr}
   #- ${internal.lr_invariant}
   #- ${internal.hr_invariant}
+  #- ${internal.my_model}

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -22,6 +22,6 @@ output_path: /home/sbeairsto/data-sbeairsto/config_test
 # Define the list of climate models to include (injected in `injections.yaml`)
 climate_models:
   #- ${internal.hr}
-  #- ${internal.lr}  # Uncomment to include low-resolution model
-  - ${internal.lr_invariant}
-  - ${internal.hr_invariant}
+  - ${internal.lr}
+  #- ${internal.lr_invariant}
+  #- ${internal.hr_invariant}

--- a/nc2pt/conf/paths.yaml
+++ b/nc2pt/conf/paths.yaml
@@ -7,7 +7,7 @@ paths:
   # ────────────────────────────────────────
   # User-dependent path for HR reference grid
   # ────────────────────────────────────────
-  hr_ref: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
+  hr_ref: /home/username/projects/nc2pt/nc2pt/data/hr_ref.nc
 
   # ────────────────────────────────────────
   # Shared data paths – High-Resolution WRF (HR)
@@ -31,6 +31,10 @@ paths:
   # Shared invariant fields (e.g., orography, landmask)
   # ────────────────────────────────────────
   hr_invariant: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/CA4km_const.nc
+
+
+  
+
 
   # ────────────────────────────────────────
   # User-dependent path for My Model Template

--- a/nc2pt/conf/select.yaml
+++ b/nc2pt/conf/select.yaml
@@ -8,11 +8,11 @@ select:
     # Define the full available date range
     range:
       start: "20001001T06:00:00"
-      end: "20001101T12:00:00"
+      end: "20010101T12:00:00"
 
     # Select years to reserve for testing and validation
     # Remaining years are used for training
-    test_years: [None]
+    test_years: [2001]
     validation_years: [None]
 
   # ───── Spatial subsetting ─────

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -7,6 +7,7 @@ from hydra.utils import instantiate
 from typing import Union, List
 from nc2pt.climatedata import ClimateDimension, ClimateVariable, ClimateData
 import xarray as xr
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 
 class MultipleKeys(Exception):
@@ -52,7 +53,16 @@ class NormalizerMetadataCollector:
         Returns:
             SHA256 hash string.
         """
-        temp = {k: v for k, v in data.items() if k != "hash"}
+        # Exclude 'hash' and convert each value if needed
+        temp = {}
+        for k, v in data.items():
+            if k == "hash":
+                continue
+            if OmegaConf.is_config(v):  # Handles both DictConfig and ListConfig
+                temp[k] = OmegaConf.to_container(v, resolve=True)
+            else:
+                temp[k] = v
+
         temp_json = json.dumps(temp, sort_keys=True)
         return hashlib.sha256(temp_json.encode()).hexdigest()
 
@@ -112,6 +122,29 @@ class NormalizerMetadataCollector:
             if model.name == model_name and model.hr_ref is not None:
                 return model.hr_ref.path
         return None
+    
+    def _convert_nested_omegaconf(self, obj):
+        """
+        Recursively convert any OmegaConf DictConfig or ListConfig to plain Python dicts/lists.
+
+        Parameters
+        ----------
+        obj : Any
+            Object potentially containing OmegaConf configs.
+
+        Returns
+        -------
+        Any
+            A fully OmegaConf-free version of the input object.
+        """
+        if isinstance(obj, (DictConfig, ListConfig)):
+            return OmegaConf.to_container(obj, resolve=True)
+        elif isinstance(obj, dict):
+            return {k: self._convert_nested_omegaconf(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._convert_nested_omegaconf(v) for v in obj]
+        else:
+            return obj
 
     def log_variable_units_from_dataset(self, variable_name: str, ds: xr.Dataset) -> None:
         """
@@ -193,11 +226,16 @@ class NormalizerMetadataCollector:
             return
 
         for var_name, meta in self.metadata.items():
+            # Add the hash first (must be added to the original dict)
             meta["hash"] = self._compute_hash(meta)
+
+            # Convert entire metadata dict to a plain dict recursively
+            meta_clean = self._convert_nested_omegaconf(meta)
+
             out_path = self.output_dir / f"{var_name}_normalization_metadata.json"
             logging.info(f"📝 Writing metadata for '{var_name}' to {out_path}")
             with out_path.open("w") as f:
-                json.dump(meta, f, indent=2)
+                json.dump(meta_clean, f, indent=2)
             logging.info(f"✅ Wrote: {out_path}")
 
 

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -56,22 +56,29 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         ds = configure_metadata_fn(ds, climate_variable)
         metadata_collector.log_variable_units_from_dataset(climate_variable.name, ds)
         ds = climdata.apply_chunks(ds)
-        ds_aligned = run_alignment_pipeline(ds, model, climdata, hr_ref)
+        ds_aligned = run_alignment_pipeline(ds, climate_variable, model, climdata, hr_ref)
         ds_aligned = apply_feature_scaling(ds_aligned, climate_variable)
+        reference_key = "train" if "train" in ds_aligned else "full"
+        metadata_collector.add_variable_from_config(
+            climate_data=climdata,
+            climate_variable=climate_variable,
+            processed_ds=ds_aligned[reference_key],
+            model_name=model.name
+        )
 
-        for dataset in ds_aligned:
-            # metadata_collector.add_variable_from_config(climate_data=climdata,
-            #                                             climate_variable=climate_variable,
-            #                                             processed_ds=["train"],
-            #                                             model_name=model.name)
-            write_to_zarr(
-                    climdata.apply_chunks(ds_aligned[dataset]),
-                    f"{climdata.output_path}/{climate_variable.name}_{dataset}_{model.name}",
-                )
+        for dataset_key, dataset in ds_aligned.items():
+            # Skip 'full' in filename if not split
+            if dataset_key == "full":
+                out_path = f"{climdata.output_path}/{climate_variable.name}_{model.name}"
+            else:
+                out_path = f"{climdata.output_path}/{climate_variable.name}_{dataset_key}_{model.name}"
+            logging.info(f"✨ Writing {dataset_key} output...")
+            write_to_zarr(climdata.apply_chunks(dataset), out_path)
+
         end = timer()
         logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
         logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
-        del ds
+        del ds, ds_aligned
     metadata_collector.write_all()
 
         # ds = (

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -29,15 +29,10 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
 
     configure_metadata_fn = partial(configure_metadata, climdata=climdata)
     metadata_collector = NormalizerMetadataCollector(climdata.output_path)
-    alignment_procedures = {}
     if model.hr_ref is not None:
         hr_ref = load_grid(model.hr_ref.path, engine=climdata.compute.engine)
         logging.info("👀 Processing high resolution reference field...")
         hr_ref = configure_metadata_fn(hr_ref, instantiate(model.hr_ref))
-        alignment_procedures |= {
-            "lr": partial(align_with_lr, hr_ref=hr_ref, climdata=climdata),
-            "lr_invariant": partial(align_with_lr, hr_ref=hr_ref, climdata=climdata),
-        }
     else: hr_ref = None
 
     for climate_variable in model.climate_variables:

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,6 +1,6 @@
 from nc2pt.metadata import configure_metadata, NormalizerMetadataCollector
 from nc2pt.io import load_grid, write_to_zarr
-from nc2pt.align import align_with_lr, crop_field, slice_time
+from nc2pt.align import align_with_lr, crop_field, slice_time, run_alignment_pipeline
 from nc2pt.computations import split_and_standardize, standardize_or_normalize
 from nc2pt.climatedata import ClimateData, ClimateModel
 
@@ -39,6 +39,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
             "lr": partial(align_with_lr, hr_ref=hr_ref, climdata=climdata),
             "lr_invariant": partial(align_with_lr, hr_ref=hr_ref, climdata=climdata),
         }
+    else: hr_ref = None
 
     for climate_variable in model.climate_variables:
         # Instantiates climate_variable object in cliamtedata.py
@@ -55,67 +56,68 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         ds = configure_metadata_fn(ds, climate_variable)
         metadata_collector.log_variable_units_from_dataset(climate_variable.name, ds)
         ds = climdata.apply_chunks(ds)
+        ds = run_alignment_pipeline(ds, model, climdata, hr_ref)
 
-        ds = (
-            slice_time(
-                ds, climdata.select.time.range.start, climdata.select.time.range.end
-            )
-            if climate_variable.invariant is False
-            else ds
-        )
+        # ds = (
+        #     slice_time(
+        #         ds, climdata.select.time.range.start, climdata.select.time.range.end
+        #     )
+        #     if climate_variable.invariant is False
+        #     else ds
+        # )
 
-        alignment_procedures |= {
-            "hr": partial(
-                crop_field,
-                scale_factor=climdata.select.spatial.scale_factor,
-                x=climdata.select.spatial.x,
-                y=climdata.select.spatial.y,
-            ),
-            "hr_invariant": partial(
-                crop_field,
-                scale_factor=climdata.select.spatial.scale_factor,
-                x=climdata.select.spatial.x,
-                y=climdata.select.spatial.y,
-            ),
-            "lr_invariant": partial(
-                crop_field,
-                scale_factor=climdata.select.spatial.scale_factor,
-                x=climdata.select.spatial.x,
-                y=climdata.select.spatial.y,
-                downsample=getattr(model, "downsample", False),
-            ),
-        }
+        # alignment_procedures |= {
+        #     "hr": partial(
+        #         crop_field,
+        #         scale_factor=climdata.select.spatial.scale_factor,
+        #         x=climdata.select.spatial.x,
+        #         y=climdata.select.spatial.y,
+        #     ),
+        #     "hr_invariant": partial(
+        #         crop_field,
+        #         scale_factor=climdata.select.spatial.scale_factor,
+        #         x=climdata.select.spatial.x,
+        #         y=climdata.select.spatial.y,
+        #     ),
+        #     "lr_invariant": partial(
+        #         crop_field,
+        #         scale_factor=climdata.select.spatial.scale_factor,
+        #         x=climdata.select.spatial.x,
+        #         y=climdata.select.spatial.y,
+        #         downsample=getattr(model, "downsample", False),
+        #     ),
+        # }
 
-        # This implies that it is a different grid or a lr dataset.
-        ds = alignment_procedures[model.name](ds)
-        if climate_variable.invariant is False:
-            train_test_validation_ds = split_and_standardize(
-                ds, climdata, climate_variable
-            )
-            metadata_collector.add_variable_from_config(climate_data=climdata,
-                                                        climate_variable=climate_variable,
-                                                        processed_ds=train_test_validation_ds["train"],
-                                                        model_name=model.name)
-            for train_test_validation in train_test_validation_ds:
-                logging.info(f"✨ Writing {train_test_validation} output...")
-                write_to_zarr(
-                    climdata.apply_chunks(train_test_validation_ds[train_test_validation]),
-                    f"{climdata.output_path}/{climate_variable.name}_{train_test_validation}_{model.name}",
-                )
+        # # This implies that it is a different grid or a lr dataset.
+        # ds = alignment_procedures[model.name](ds)
+        # if climate_variable.invariant is False:
+        #     train_test_validation_ds = split_and_standardize(
+        #         ds, climdata, climate_variable
+        #     )
+        #     metadata_collector.add_variable_from_config(climate_data=climdata,
+        #                                                 climate_variable=climate_variable,
+        #                                                 processed_ds=train_test_validation_ds["train"],
+        #                                                 model_name=model.name)
+        #     for train_test_validation in train_test_validation_ds:
+        #         logging.info(f"✨ Writing {train_test_validation} output...")
+        #         write_to_zarr(
+        #             climdata.apply_chunks(train_test_validation_ds[train_test_validation]),
+        #             f"{climdata.output_path}/{climate_variable.name}_{train_test_validation}_{model.name}",
+        #         )
 
-        else:
-            ds = standardize_or_normalize(ds, climate_variable)
-            logging.info("✨ Writing output...")
-            write_to_zarr(
-                climdata.apply_chunks(ds),
-                f"{climdata.output_path}/{climate_variable.name}_{model.name}",
-            )
+        # else:
+        #     ds = standardize_or_normalize(ds, climate_variable)
+        #     logging.info("✨ Writing output...")
+        #     write_to_zarr(
+        #         climdata.apply_chunks(ds),
+        #         f"{climdata.output_path}/{climate_variable.name}_{model.name}",
+        #     )
 
-        end = timer()
-        logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
-        logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
-        del ds
-    metadata_collector.write_all()
+        # end = timer()
+        # logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
+        # logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
+        # del ds
+    #metadata_collector.write_all()
 
 
 def preprocess(climdata: ClimateData) -> None:

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -81,67 +81,6 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         del ds, ds_aligned
     metadata_collector.write_all()
 
-        # ds = (
-        #     slice_time(
-        #         ds, climdata.select.time.range.start, climdata.select.time.range.end
-        #     )
-        #     if climate_variable.invariant is False
-        #     else ds
-        # )
-
-        # alignment_procedures |= {
-        #     "hr": partial(
-        #         crop_field,
-        #         scale_factor=climdata.select.spatial.scale_factor,
-        #         x=climdata.select.spatial.x,
-        #         y=climdata.select.spatial.y,
-        #     ),
-        #     "hr_invariant": partial(
-        #         crop_field,
-        #         scale_factor=climdata.select.spatial.scale_factor,
-        #         x=climdata.select.spatial.x,
-        #         y=climdata.select.spatial.y,
-        #     ),
-        #     "lr_invariant": partial(
-        #         crop_field,
-        #         scale_factor=climdata.select.spatial.scale_factor,
-        #         x=climdata.select.spatial.x,
-        #         y=climdata.select.spatial.y,
-        #         downsample=getattr(model, "downsample", False),
-        #     ),
-        # }
-
-        # # This implies that it is a different grid or a lr dataset.
-        # ds = alignment_procedures[model.name](ds)
-        # if climate_variable.invariant is False:
-        #     train_test_validation_ds = split_and_standardize(
-        #         ds, climdata, climate_variable
-        #     )
-        #     metadata_collector.add_variable_from_config(climate_data=climdata,
-        #                                                 climate_variable=climate_variable,
-        #                                                 processed_ds=train_test_validation_ds["train"],
-        #                                                 model_name=model.name)
-        #     for train_test_validation in train_test_validation_ds:
-        #         logging.info(f"✨ Writing {train_test_validation} output...")
-        #         write_to_zarr(
-        #             climdata.apply_chunks(train_test_validation_ds[train_test_validation]),
-        #             f"{climdata.output_path}/{climate_variable.name}_{train_test_validation}_{model.name}",
-        #         )
-
-        # else:
-        #     ds = standardize_or_normalize(ds, climate_variable)
-        #     logging.info("✨ Writing output...")
-        #     write_to_zarr(
-        #         climdata.apply_chunks(ds),
-        #         f"{climdata.output_path}/{climate_variable.name}_{model.name}",
-        #     )
-
-        # end = timer()
-        # logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
-        # logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
-        # del ds
-    #metadata_collector.write_all()
-
 
 def preprocess(climdata: ClimateData) -> None:
     for climate_model in climdata.climate_models:

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,7 +1,6 @@
 from nc2pt.metadata import configure_metadata, NormalizerMetadataCollector
 from nc2pt.io import load_grid, write_to_zarr
-from nc2pt.align import align_with_lr, crop_field, slice_time, run_alignment_pipeline, apply_feature_scaling
-#from nc2pt.computations import split_and_standardize, standardize_or_normalize
+from nc2pt.align import align_with_lr, run_alignment_pipeline, apply_feature_scaling
 from nc2pt.climatedata import ClimateData, ClimateModel
 
 import logging
@@ -59,6 +58,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         ds_aligned = run_alignment_pipeline(ds, climate_variable, model, climdata, hr_ref)
         ds_aligned = apply_feature_scaling(ds_aligned, climate_variable)
         reference_key = "train" if "train" in ds_aligned else "full"
+
         metadata_collector.add_variable_from_config(
             climate_data=climdata,
             climate_variable=climate_variable,

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,7 +1,7 @@
 from nc2pt.metadata import configure_metadata, NormalizerMetadataCollector
 from nc2pt.io import load_grid, write_to_zarr
-from nc2pt.align import align_with_lr, crop_field, slice_time, run_alignment_pipeline
-from nc2pt.computations import split_and_standardize, standardize_or_normalize
+from nc2pt.align import align_with_lr, crop_field, slice_time, run_alignment_pipeline, apply_feature_scaling
+#from nc2pt.computations import split_and_standardize, standardize_or_normalize
 from nc2pt.climatedata import ClimateData, ClimateModel
 
 import logging
@@ -56,7 +56,23 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         ds = configure_metadata_fn(ds, climate_variable)
         metadata_collector.log_variable_units_from_dataset(climate_variable.name, ds)
         ds = climdata.apply_chunks(ds)
-        ds = run_alignment_pipeline(ds, model, climdata, hr_ref)
+        ds_aligned = run_alignment_pipeline(ds, model, climdata, hr_ref)
+        ds_aligned = apply_feature_scaling(ds_aligned, climate_variable)
+
+        for dataset in ds_aligned:
+            # metadata_collector.add_variable_from_config(climate_data=climdata,
+            #                                             climate_variable=climate_variable,
+            #                                             processed_ds=["train"],
+            #                                             model_name=model.name)
+            write_to_zarr(
+                    climdata.apply_chunks(ds_aligned[dataset]),
+                    f"{climdata.output_path}/{climate_variable.name}_{dataset}_{model.name}",
+                )
+        end = timer()
+        logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
+        logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
+        del ds
+    metadata_collector.write_all()
 
         # ds = (
         #     slice_time(

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,6 +1,6 @@
 from nc2pt.metadata import configure_metadata, NormalizerMetadataCollector
 from nc2pt.io import load_grid, write_to_zarr
-from nc2pt.align import align_with_lr, run_alignment_pipeline, apply_feature_scaling
+from nc2pt.align import run_alignment_pipeline, apply_feature_scaling
 from nc2pt.climatedata import ClimateData, ClimateModel
 
 import logging


### PR DESCRIPTION
**Summary:**  
This PR introduces support for defining customizable preprocessing pipelines per model using the new `alignment_pipeline` field in the `ClimateModel` config. This allows users to specify which preprocessing steps to apply (and in what order), enabling more flexible and targeted workflows without modifying the core logic.

**Changes Included:**

-   Introduced `alignment_pipeline` as a list of strings in each model's YAML config. Defaults to `["temporal_crop", "regrid", "spatial_crop", "user_defined_transforms", "coarsen"]` if unspecified.
    
-   Refactored pipeline logic in `run_alignment_pipeline()` to iterate over this list and call registered functions accordingly.
    
-   Implemented individual functions for each step (`apply_temporal_crop`, `apply_regrid`, etc.).
    
-   Added a new `apply_data_split()` step to split data into train/test/validation sets based on years defined in the config. The pipeline now consistently returns a dictionary, even for unsplit datasets (via a `"full"` key).
    
-   Updated `apply_feature_scaling()` to work with both split (`"train"`, `"test"`, `"validation"`) and unsplit (`"full"`) datasets.
    
-   Metadata and save-path logic updated:
    
    -   Metadata collection uses `"train"` for split datasets and `"full"` for unsplit ones.
        
    -   Zarr outputs omit the `"full"` tag from filenames to remain concise (e.g., `tas_lr.zarr` instead of `tas_full_lr.zarr`).
        
-   Updated README with documentation on the new pipeline logic and example usage.
    

**Other Notes:**

-   No changes were made to the underlying preprocessing logic or transformation behaviour.