### PR TITLE
make sure ds is updated by coarsening

### DIFF
--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -143,7 +143,7 @@ def apply_coarsen(ds: xr.DataArray,
         Coarsened dataset.
     """
     scale_factor = climdata.select.spatial.scale_factor
-    coarsen_lr(ds, scale_factor)
+    ds = coarsen_lr(ds, scale_factor)
     logging.info(f"🪛  Coarsened field by a factor of {scale_factor}")
     return ds
 


### PR DESCRIPTION
### Description:
This pull request fixes an issue with the `apply_coarsen` function where the coarsening operation was not being applied to the dataset. The original implementation called `coarsen_lr(ds, scale_factor)` without capturing the returned value, resulting in the full-resolution dataset being returned. With the updated code, we assign the output of `coarsen_lr` to `ds` (`ds = coarsen_lr(ds, scale_factor)`) ensuring that the dataset is coarsened as expected. This should resolve the issue where datasets appeared unmodified after applying coarsening.