### PR TITLE
Add target grid coordinate saving to preprocessing

### DIFF
--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable
 import xarray as xr
 
-from nc2pt.climatedata import ClimateData, ClimateModel, ClimateVariable
+from nc2pt.climatedata import ClimateData, ClimateModel, ClimateVariable, FeatureScalingMetadata
 from nc2pt.computations import user_defined_transform, interpolate
 from nc2pt.utils import slice_time, train_test_split, crop_field, coarsen_lr
 
@@ -211,11 +211,14 @@ def apply_data_split(ds: xr.DataArray,
     return full_ds
 
 
-def run_alignment_pipeline(ds: xr.DataArray,
-                           var: ClimateVariable,
-                           model: ClimateModel,
-                           climdata: ClimateData,
-                           hr_ref: xr.DataArray) -> dict[str, xr.DataArray]:
+def run_alignment_pipeline(
+    ds: xr.DataArray,
+    var: ClimateVariable,
+    model: ClimateModel,
+    climdata: ClimateData,
+    hr_ref: xr.DataArray,
+    metadata_collector: FeatureScalingMetadata = None
+) -> dict[str, xr.DataArray]:
     """
     Execute the alignment pipeline for a given climate model.
 
@@ -224,13 +227,15 @@ def run_alignment_pipeline(ds: xr.DataArray,
     ds : xr.DataArray
         Input dataset to process.
     var : ClimateVariable
-        Climate variable containing custom transformation proceedures.
+        Climate variable containing custom transformation procedures.
     model : ClimateModel
         Climate model containing the alignment pipeline steps.
     climdata : ClimateData
         Global configuration for the preprocessing run.
     hr_ref : xr.DataArray
         Optional high-resolution reference field for regridding.
+    metadata_collector : FeatureScalingMetadata, optional
+        Collector for saving grid and metadata.
 
     Returns
     -------
@@ -250,6 +255,7 @@ def run_alignment_pipeline(ds: xr.DataArray,
 
     if not isinstance(ds, dict):
         ds = {"full": ds}
+
     return ds
 
 

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -17,13 +17,13 @@ defaults:
   - loader               # Loader config (batch size, shuffling, etc.)
 
 _target_: nc2pt.climatedata.ClimateData
-output_path: /home/username/output/path
+output_path: /home/sbeairsto/data-sbeairsto/van_isle_128_testing
 
 # Define the list of climate models to include (injected in `injections.yaml`)
 climate_models:
-  - ${internal.hr}
-  - ${internal.lr}
+  #- ${internal.hr}
+  #- ${internal.lr}
   #- ${internal.lr_invariant}
-  #- ${internal.hr_invariant}
+  - ${internal.hr_invariant}
   #- ${internal.lr_emulation}
   #- ${internal.my_model}

--- a/nc2pt/conf/paths.yaml
+++ b/nc2pt/conf/paths.yaml
@@ -7,7 +7,7 @@ paths:
   # ────────────────────────────────────────
   # User-dependent path for HR reference grid
   # ────────────────────────────────────────
-  hr_ref: /home/username/projects/nc2pt/nc2pt/data/hr_ref.nc
+  hr_ref: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
 
   # ────────────────────────────────────────
   # Shared data paths – High-Resolution WRF (HR)

--- a/nc2pt/conf/select.yaml
+++ b/nc2pt/conf/select.yaml
@@ -19,8 +19,8 @@ select:
   spatial:
     scale_factor: 8  # Factor to downscale HR data to LR
     x:
-      first_index: 110
-      last_index: 622
+      first_index: 125
+      last_index: 253
     y:
-      first_index: 20
-      last_index: 532
+      first_index: 100
+      last_index: 228

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -1,13 +1,18 @@
 import json
 import hashlib
+from typing import Optional
 from datetime import datetime
 from pathlib import Path
+import pandas as pd
 import logging
 from hydra.utils import instantiate
 from typing import Union, List
-from nc2pt.climatedata import ClimateDimension, ClimateVariable, ClimateData
 import xarray as xr
 from omegaconf import DictConfig, ListConfig, OmegaConf
+
+from nc2pt.climatedata import ClimateDimension, ClimateVariable, ClimateData
+from nc2pt.utils import crop_field
+
 
 
 class MultipleKeys(Exception):
@@ -41,6 +46,8 @@ class NormalizerMetadataCollector:
         self.metadata = {}
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.grid_dir = self.output_dir / "grid"
+        self._grid_saved = {}
         logging.info(f"📁 NormalizerMetadataCollector initialized with output dir: {self.output_dir}")
 
     def _compute_hash(self, data: dict) -> str:
@@ -122,7 +129,7 @@ class NormalizerMetadataCollector:
             if model.name == model_name and model.hr_ref is not None:
                 return model.hr_ref.path
         return None
-    
+
     def _convert_nested_omegaconf(self, obj):
         """
         Recursively convert any OmegaConf DictConfig or ListConfig to plain Python dicts/lists.
@@ -145,6 +152,132 @@ class NormalizerMetadataCollector:
             return [self._convert_nested_omegaconf(v) for v in obj]
         else:
             return obj
+
+    def _create_grid_dataset(self, hr_dataset: xr.Dataset) -> Optional[xr.Dataset]:
+        """
+        Create minimal grid dataset with coordinates and projection info.
+
+        Args:
+            hr_dataset: High-resolution dataset with lat/lon coordinates
+
+        Returns:
+            Grid dataset, or None if required coordinates missing
+        """
+        if 'lat' not in hr_dataset.coords or 'lon' not in hr_dataset.coords:
+            logging.warning(f"⚠ Dataset missing lat/lon coordinates, skipping grid save")
+            return None
+
+        if 'rlat' not in hr_dataset.dims or 'rlon' not in hr_dataset.dims:
+            logging.warning(f"⚠ Dataset missing rlat/rlon dimensions, skipping grid save")
+            return None
+
+        grid_ds = xr.Dataset(
+            coords={
+                'rlat': hr_dataset.rlat,
+                'rlon': hr_dataset.rlon,
+                'lat': (['rlat', 'rlon'], hr_dataset.lat.values),
+                'lon': (['rlat', 'rlon'], hr_dataset.lon.values),
+            }
+        )
+
+        for proj_var in ['rotated_pole', 'rotated_latitude_longitude']:
+            if proj_var in hr_dataset:
+                grid_ds[proj_var] = hr_dataset[proj_var]
+                break
+
+        for coord in ['lat', 'lon', 'rlat', 'rlon']:
+            if coord in hr_dataset.coords and hr_dataset[coord].attrs:
+                grid_ds[coord].attrs.update(hr_dataset[coord].attrs)
+
+        return grid_ds
+
+    def _add_grid_metadata(
+        self,
+        grid_ds: xr.Dataset,
+        model_name: str,
+        spatial_crop: Optional[dict] = None
+    ) -> xr.Dataset:
+        """
+        Add metadata attributes to grid dataset.
+
+        Args:
+            grid_ds: Grid dataset
+            model_name: Name of the model
+            spatial_crop: Crop indices used
+
+        Returns:
+            Grid dataset with metadata added
+        """
+        grid_ds.attrs.update({
+            'description': 'Target grid definition for downscaled climate data',
+            'title': f'Target grid for {model_name} preprocessing',
+            'created': pd.Timestamp.now().isoformat(),
+            'source': 'nc2pt preprocessing pipeline',
+            'model': model_name,
+            'purpose': 'Geospatial coordinates for data regridded/cropped to this domain',
+        })
+
+        if spatial_crop:
+            grid_ds.attrs['spatial_crop_x'] = f"{spatial_crop['x'][0]}:{spatial_crop['x'][1]}"
+            grid_ds.attrs['spatial_crop_y'] = f"{spatial_crop['y'][0]}:{spatial_crop['y'][1]}"
+
+        return grid_ds
+
+    def save_grid_if_needed(
+        self, 
+        hr_dataset: xr.Dataset, 
+        model_name: str,
+        climdata: ClimateData
+    ) -> Optional[str]:
+        """
+        Crop and save target grid definition for model if not already saved.
+        
+        This saves the high-resolution target grid that variables are
+        regridded/aligned to during preprocessing.
+        
+        Args:
+            hr_dataset: High-resolution dataset before cropping
+            model_name: Name of the model
+            climdata: Global configuration containing spatial crop settings
+            
+        Returns:
+            Relative path to grid file, or None if not saved
+        """
+        if model_name in self._grid_saved:
+            logging.debug(f"📐 Target grid for {model_name} already saved")
+            return self._grid_saved[model_name]
+        
+        # Crop the HR grid using config settings
+        hr_dataset = crop_field(
+            hr_dataset,
+            climdata.select.spatial.scale_factor,
+            climdata.select.spatial.x,
+            climdata.select.spatial.y
+        )
+        
+        grid_ds = self._create_grid_dataset(hr_dataset)
+        if grid_ds is None:
+            return None
+        
+        # Extract spatial crop info from config
+        spatial_crop = {
+            'x': [climdata.select.spatial.x.first_index, 
+                climdata.select.spatial.x.last_index],
+            'y': [climdata.select.spatial.y.first_index, 
+                climdata.select.spatial.y.last_index]
+        }
+        
+        grid_ds = self._add_grid_metadata(grid_ds, model_name, spatial_crop)
+        
+        self.grid_dir.mkdir(parents=True, exist_ok=True)
+        grid_file = self.grid_dir / "hr_target_grid.nc"
+        
+        grid_ds.to_netcdf(grid_file)
+        logging.info(f"📐 Saved target grid definition: {grid_file}")
+        
+        relative_path = f"../grid/hr_target_grid.nc"
+        self._grid_saved[model_name] = relative_path
+        return relative_path
 
     def log_variable_units_from_dataset(self, variable_name: str, ds: xr.Dataset) -> None:
         """
@@ -210,6 +343,9 @@ class NormalizerMetadataCollector:
             "hr_reference_field": self._get_hr_ref_path(climate_data, model_name),
             "created": datetime.utcnow().isoformat() + "Z",
         })
+
+        if model_name in self._grid_saved:
+            self.metadata[var_name]["grid_file"] = self._grid_saved[model_name]
 
         # Ensure 'units' dict exists and has both keys set
         self.metadata[var_name].setdefault("units", {})
@@ -431,3 +567,6 @@ def drop_unused_variables(
     ds = ds.drop_vars(to_drop, errors="ignore")
 
     return ds
+
+
+

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -34,6 +34,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         hr_ref = load_grid(model.hr_ref.path, engine=climdata.compute.engine)
         logging.info("👀 Processing high resolution reference field...")
         hr_ref = configure_metadata_fn(hr_ref, instantiate(model.hr_ref))
+        metadata_collector.save_grid_if_needed(hr_ref, model.name, climdata)
     else: hr_ref = None
 
     for climate_variable in model.climate_variables:
@@ -51,7 +52,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         ds = configure_metadata_fn(ds, climate_variable)
         metadata_collector.log_variable_units_from_dataset(climate_variable.name, ds)
         ds = climdata.apply_chunks(ds)
-        ds_aligned = run_alignment_pipeline(ds, climate_variable, model, climdata, hr_ref)
+        ds_aligned = run_alignment_pipeline(ds, climate_variable, model, climdata, hr_ref, metadata_collector)
         ds_aligned = apply_feature_scaling(ds_aligned, climate_variable, model)
         reference_key = "train" if "train" in ds_aligned else "full"
 


### PR DESCRIPTION
## Summary

Adds functionality to save high-resolution target grid coordinates (lat/lon) as a NetCDF file during preprocessing. This enables proper geospatial visualization and evaluation of downscaled outputs.

## Motivation

After preprocessing, inference outputs (.pt files) lack geospatial coordinate information. This makes it difficult to:

-   Plot data on maps with proper projections
-   Calculate spatial metrics requiring true distances
-   Compare outputs with other climate datasets

## Changes

### Modified Files

**`nc2pt/climatedata.py`**

-   Added  `grid_file`  field to  `FeatureScalingMetadata`  dataclass to store reference to grid file

**`nc2pt/metadata.py`**

-   Added  `grid_dir`  and  `_grid_saved`  tracking to  `NormalizerMetadataCollector.__init__`
-   Added three new methods:
    -   `_create_grid_dataset()`: Creates minimal grid dataset with coordinates and projection info
    -   `_add_grid_metadata()`: Adds metadata attributes to grid dataset
    -   `save_grid_if_needed()`: Main method to crop and save target grid (saves once per model)
-   Updated  `add_variable_from_config()`  to add grid file reference to variable metadata

**`nc2pt/preprocess.py`**

-   Added call to  `metadata_collector.save_grid_if_needed()`  after loading and configuring  `hr_ref`

### Output Structure

```css
output/
├── grid/
│   └── hr_target_grid.nc     # New: 128×128 target grid with lat/lon
└── {model}_{var}_feature_scaling_metadata.json  # Updated: includes "grid_file" field
└── {variable}_{split}_{model}.zarr/` 
```

### Grid File Contents

-   **Dimensions**:  `rlat`,  `rlon`  (grid indices)
-   **Coordinates**:
    -   `rlat`,  `rlon`  (1D arrays)
    -   `lat`,  `lon`  (2D arrays mapping grid to geographic coordinates)
-   **Variables**:  `rotated_pole`  (projection information)
-   **Attributes**: Created timestamp, spatial crop info, model name

## Testing

Verified that:

-   ✅ Grid saved at cropped HR field resolution (target resolution, not LR covariate resolution)
-   ✅ Grid coordinates match those in preprocessed HR zarr files
-   ✅ Grid file properly references rotated pole projection

## Notes

-   Grid is saved  **once per model**  (not per variable) to avoid duplication
-   Grid is cropped using same spatial crop parameters as preprocessing
-   Only saved when  `hr_ref`  is present (LR preprocessing runs)
-   Relative path stored in metadata enables portability