### PR TITLE
Small tweaks

### DIFF
--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -19,7 +19,6 @@ class ClimateVariable:
     name: str
     alternative_names: List[str]
     path: str
-    is_west_negative: bool
     transform: Optional[str] = field(default=None)
     invariant: Optional[bool] = field(default=False)
     apply_standardize: Optional[bool] = field(default=True)
@@ -96,7 +95,6 @@ class FeatureScalingMetadata:
     apply_normalize: bool = False
     apply_standardize: bool = False
     transforms: List = False
-    is_west_negative: bool = False
     spatial_scale_factor: int = 1
     spatial_crop: Optional[dict] = None
     hr_reference_field: Optional[str] = None

--- a/nc2pt/conf/climate_models/hr.yaml
+++ b/nc2pt/conf/climate_models/hr.yaml
@@ -11,6 +11,6 @@ loader: "ubc_wrf"
 climate_variables:
   #- ${internal.hr_uas}
   #- ${internal.hr_vas}
-  #- ${internal.hr_tas}
+  - ${internal.hr_tas}
   #- ${internal.hr_ps}
-  - ${internal.hr_pr}
+  #- ${internal.hr_pr}

--- a/nc2pt/conf/climate_models/hr/pr.yaml
+++ b/nc2pt/conf/climate_models/hr/pr.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "pr"
 alternative_names: ["PREC", "HPRECIPNC"]
 path:  ${internal.paths.hr.pr}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/hr/ps.yaml
+++ b/nc2pt/conf/climate_models/hr/ps.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "ps"
 alternative_names: ["PSFC"]
 path:  ${internal.paths.hr.ps}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/hr/tas.yaml
+++ b/nc2pt/conf/climate_models/hr/tas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "tas"
 alternative_names: ["T2", "surface temperature"]
 path: ${internal.paths.hr.tas}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/hr/uas.yaml
+++ b/nc2pt/conf/climate_models/hr/uas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "uas"
 alternative_names: ["U10", "u10", "uas"]
 path: ${internal.paths.hr.uas}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/hr/vas.yaml
+++ b/nc2pt/conf/climate_models/hr/vas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "vas"
 alternative_names: ["V10", "v10", "vas"]
 path: ${internal.paths.hr.vas}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/hr_invariant.yaml
+++ b/nc2pt/conf/climate_models/hr_invariant.yaml
@@ -10,6 +10,6 @@ alignment_pipeline: ['spatial_crop']
 
 climate_variables:
   - ${internal.hr_invariant_topo}
-  - ${internal.hr_invariant_land_mask}
-  - ${internal.hr_invariant_land_use}
-  - ${internal.hr_invariant_surface_roughness}
+  #- ${internal.hr_invariant_land_mask}
+  #- ${internal.hr_invariant_land_use}
+  #- ${internal.hr_invariant_surface_roughness}

--- a/nc2pt/conf/climate_models/hr_invariant/land_mask.yaml
+++ b/nc2pt/conf/climate_models/hr_invariant/land_mask.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "land_mask"
 alternative_names: ["LANDMASK"]
 path: ${internal.paths.hr_invariant}
-is_west_negative: false
 invariant: true
 apply_standardize: false
 apply_normalize: true

--- a/nc2pt/conf/climate_models/hr_invariant/land_use.yaml
+++ b/nc2pt/conf/climate_models/hr_invariant/land_use.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "land_use"
 alternative_names: ["LU_INDEX"]
 path: ${internal.paths.hr_invariant}
-is_west_negative: false
 invariant: true
 apply_standardize: false
 apply_normalize: true

--- a/nc2pt/conf/climate_models/hr_invariant/surface_roughness.yaml
+++ b/nc2pt/conf/climate_models/hr_invariant/surface_roughness.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "surface_roughness"
 alternative_names: ["VAR_SSO"]
 path: ${internal.paths.hr_invariant}
-is_west_negative: false
 invariant: true
 apply_standardize: false
 apply_normalize: true

--- a/nc2pt/conf/climate_models/hr_invariant/topo.yaml
+++ b/nc2pt/conf/climate_models/hr_invariant/topo.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "topography"
 alternative_names: ["HGT"]
 path: ${internal.paths.hr_invariant}
-is_west_negative: false
 invariant: true
 apply_standardize: false
 apply_normalize: true

--- a/nc2pt/conf/climate_models/lr.yaml
+++ b/nc2pt/conf/climate_models/lr.yaml
@@ -14,13 +14,12 @@ hr_ref:
   name: "hr_ref"
   alternative_names: ["HGT"]
   path: ${internal.paths.hr_ref}
-  is_west_negative: true
   invariant: true
 
 climate_variables:
   # Activate variables to include in the LR model
   # - ${internal.lr_uas}
   # - ${internal.lr_vas}
-  # - ${internal.lr_tas}
+   - ${internal.lr_tas}
   # - ${internal.lr_ps}
-   - ${internal.lr_pr}
+  # - ${internal.lr_pr}

--- a/nc2pt/conf/climate_models/lr/pr.yaml
+++ b/nc2pt/conf/climate_models/lr/pr.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "pr"
 alternative_names: ["PREC"]
 path: ${internal.paths.lr.pr}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr/ps.yaml
+++ b/nc2pt/conf/climate_models/lr/ps.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "ps"
 alternative_names: ["PSFC"]
 path:  ${internal.paths.lr.ps}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr/tas.yaml
+++ b/nc2pt/conf/climate_models/lr/tas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "tas"
 alternative_names: ["T2", "surface temperature"]
 path: ${internal.paths.lr.tas}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr/uas.yaml
+++ b/nc2pt/conf/climate_models/lr/uas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "uas"
 alternative_names: ["U10", "u10", "uas"]
 path: ${internal.paths.lr.uas}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr/vas.yaml
+++ b/nc2pt/conf/climate_models/lr/vas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "vas"
 alternative_names: ["V10", "v10", "vas"]
 path: ${internal.paths.lr.vas}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr_emulation.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation.yaml
@@ -15,7 +15,6 @@ hr_ref:
   name: "hr_ref"
   alternative_names: ["T2"]
   path: ${internal.paths.hr_ref}
-  is_west_negative: true
   invariant: true
 
 climate_variables:

--- a/nc2pt/conf/climate_models/lr_emulation/pr.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation/pr.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "pr"
 alternative_names: ["PREC"]
 path: ${internal.paths.lr.pr}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr_emulation/ps.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation/ps.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "ps"
 alternative_names: ["PSFC"]
 path: ${internal.paths.lr.ps}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr_emulation/tas.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation/tas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "tas"
 alternative_names: ["T2", "surface temperature"]
 path: ${internal.paths.lr.tas}
-is_west_negative: true
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr_emulation/uas.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation/uas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "uas"
 alternative_names: ["U10", "u10", "uas"]
 path: ${internal.paths.lr.uas}
-is_west_negative: false
 apply_standardize: true
 apply_normalize: false
 invariant: false

--- a/nc2pt/conf/climate_models/lr_emulation/vas.yaml
+++ b/nc2pt/conf/climate_models/lr_emulation/vas.yaml
@@ -4,7 +4,6 @@ _target_: nc2pt.climatedata.ClimateVariable
 name: "vas"
 alternative_names: ["V10", "v10", "vas"]
 path: ${internal.paths.lr.vas}
-is_west_negative: false
 apply_standardize: false
 apply_normalize: true
 invariant: false

--- a/nc2pt/conf/climate_models/lr_invariant.yaml
+++ b/nc2pt/conf/climate_models/lr_invariant.yaml
@@ -10,6 +10,6 @@ alignment_pipeline: ['spatial_crop', 'coarsen']
 
 climate_variables:
   - ${internal.hr_invariant_topo}
-  - ${internal.hr_invariant_land_mask}
-  - ${internal.hr_invariant_land_use}
-  - ${internal.hr_invariant_surface_roughness}
+  #- ${internal.hr_invariant_land_mask}
+  #- ${internal.hr_invariant_land_use}
+  #- ${internal.hr_invariant_surface_roughness}

--- a/nc2pt/conf/climate_models/my_model.yaml
+++ b/nc2pt/conf/climate_models/my_model.yaml
@@ -11,7 +11,6 @@ info: "Custom climate model for [describe domain, resolution, etc.]"
 #   name: hr_ref
 #   alternative_names: ["T2"]
 #   path: ${internal.paths.hr_ref}
-#   is_west_negative: true
 #   invariant: true
 
 climate_variables:

--- a/nc2pt/conf/climate_models/my_model/uas.yaml
+++ b/nc2pt/conf/climate_models/my_model/uas.yaml
@@ -5,7 +5,6 @@ name: uas
 alternative_names: ["uas", "U10", "u10"]
 path: ${internal.paths.my_model.uas}
 
-is_west_negative: true
 invariant: false
 apply_standardize: false
 apply_normalize: true

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -23,7 +23,7 @@ output_path: /home/username/output/path
 climate_models:
   - ${internal.hr}
   - ${internal.lr}
-  #- ${internal.lr_invariant}
+  - ${internal.lr_invariant}
   - ${internal.hr_invariant}
   #- ${internal.lr_emulation}
   #- ${internal.my_model}

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -420,7 +420,9 @@ def configure_metadata(
     ds = rename_keys(ds, outcome_obj=var, ds_attr="data_vars")
     preserve = [dim.name for dim in climdata.dims] + [coord.name for coord in climdata.coords]
     ds = drop_unused_variables(ds, var, preserve_vars=preserve)
-    ds = match_longitudes(ds) if var.is_west_negative else ds
+
+    #ensures lat/lon are always in [-180,180] range
+    ds = normalize_longitudes_to_180(ds)
 
     return ds
 
@@ -474,25 +476,25 @@ def rename_keys(
     return ds
 
 
-def match_longitudes(ds: xr.Dataset) -> xr.Dataset:
-    """Match the longitudes of the dataset to the range [-180, 180].
+def normalize_longitudes_to_180(ds: xr.Dataset) -> xr.Dataset:
+    """Convert longitudes from [0, 360] to [-180, 180] range.
 
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset to match the longitudes of.
+        Dataset with longitudes in range [0, 360].
 
     Returns
     -------
     ds : xarray.Dataset
-        Dataset with longitudes in the range [-180, 180].
-    """
-    if ds.lon.min() > 0:
+        Da
+    if ds.lon.max() > 180:
         raise ValueError(
-            "Dataset longitudes are likely not in the range [-180, 180]"
+            "Dataset longitudes are likely not in the range [0, 360]"
             "which is the intention of this function. Check longitude units."
         )
-    ds = ds.assign_coords(lon=(ds.lon + 360))
+    ds = ds.assign_coords(lon=(((ds.lon + 180) % 360) - 180))
+    ds = ds.sortby('lon')
     return ds
 
 

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -334,7 +334,6 @@ class NormalizerMetadataCollector:
             "apply_normalize": climate_variable.apply_normalize,
             "apply_standardize": climate_variable.apply_standardize,
             "transforms": climate_variable.transform or [],
-            "is_west_negative": climate_variable.is_west_negative,
             "spatial_scale_factor": climate_data.select["spatial"]["scale_factor"],
             "spatial_crop": self._get_spatial_crop(climate_data),
             "hr_reference_field": self._get_hr_ref_path(climate_data, model_name),
@@ -477,24 +476,13 @@ def rename_keys(
 
 
 def normalize_longitudes_to_180(ds: xr.Dataset) -> xr.Dataset:
-    """Convert longitudes from [0, 360] to [-180, 180] range.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        Dataset with longitudes in range [0, 360].
-
-    Returns
-    -------
-    ds : xarray.Dataset
-        Da
-    if ds.lon.max() > 180:
-        raise ValueError(
-            "Dataset longitudes are likely not in the range [0, 360]"
-            "which is the intention of this function. Check longitude units."
-        )
-    ds = ds.assign_coords(lon=(((ds.lon + 180) % 360) - 180))
-    ds = ds.sortby('lon')
+    """Convert longitudes to [-180, 180] range.
+    
+    Safe to call on any longitude range. Idempotent.
+    """
+    if ds.lon.max() > 180:  # Only if needed (optimization)
+        ds = ds.assign_coords(lon=(((ds.lon + 180) % 360) - 180))
+        ds = ds.sortby('lon')
     return ds
 
 

--- a/nc2pt/ubc_wrf_io.py
+++ b/nc2pt/ubc_wrf_io.py
@@ -50,10 +50,14 @@ def add_ubc_wrf_timesteps(ds):
         year, month = match.groups()
         start_date = f"{year}-{month}-01"
 
-        # rename 'time' to 'Times' in precip files
-        ds = ds.rename({'time': 'Times'})
+        if 'time' in ds:
+            # rename 'time' to 'Times' in precip files
+            ds = ds.rename({'time': 'Times'})
+        elif 'XTIME' in ds:
+            # rename 'TIMEX' to 'Times' in invariant fields
+            ds = ds.rename({'XTIME': 'Times'})
         
-        # If there are days*hours+1 timesteps drop last timestep (spin-up for next month)
+        # If there are days*hours+1 timesteps drop last timestep
         if len(ds.Times)%24 == 1:
             ds = ds.isel(Times=slice(None, -1))
         
@@ -82,10 +86,6 @@ def load_ubc_wrf(path: str, engine: str = "h5netcdf", chunks: dict = None) -> xr
         else:
             file_list = path
         
-        # Filter for only COMPRESSED_SUBSETTED files
-        # file_list = [f for f in file_list if 'COMPRESSED_SUBSETTED_d03' in f]
-        # print(f"Filtered to {len(file_list)} COMPRESSED_SUBSETTED files")
-        
         # Validate files
         print("Validating files...")
         valid_files = [f for f in file_list if validate_file(f, engine)]
@@ -94,7 +94,7 @@ def load_ubc_wrf(path: str, engine: str = "h5netcdf", chunks: dict = None) -> xr
             print(f"⚠️  Skipped {len(file_list) - len(valid_files)} corrupted files")
         
         print(f"✅ Processing {len(valid_files)} valid files")
-        print("Note: Dropping last timestep of each month (corresponds to M+1 00:00:00)")
+        print("Note: Dropping last timestep of each month (corresponds to M+1 00:00:00) if extra timestep detected")
         
         ds = xr.open_mfdataset(
             paths=valid_files,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask
+h5py
 zarr
 netCDF4
 hydra-core==1.3.2


### PR DESCRIPTION
## Overview
A series of tweaks, fixing minor bugs and depricated code.

### Changed longitude handling to ALWAYS align longitudes to [-180, 180]
Replaced `metadata.align_longitudes()` function with `metadata.normalize_to_180()` function. This function is agnostic to whether or not the dataset longitudes are currently in [0, 360] or [-180, 180] format. This reduces risk of mishandling datasets.

### Removed `is_west_negative` flag
No longer necessary with new agnostic `metadata.normalize_to_180()` function.

### Set default config to preprocess `tas` only (mirroring documentation)
Allows for simplified initial run of `nc2pt`

### Fixed minor 'time' dimension handling bug in `ubc_wrf_io.py`
### Added h5py to `requirements.txt`
